### PR TITLE
Update install instructions to use --legacy-peer-deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Grab your binary from the [releases section](https://github.com/TommyX12/VIR/rel
 2. Enter the directory and install dependencies:
    ```bash
    cd VIR
-   npm install
+   npm install --legacy-peer-deps
    ```
 3. Build the binary:
    ```bash


### PR DESCRIPTION
## Overview

Before | After
--------|-------
<img width="672" alt="image" src="https://user-images.githubusercontent.com/34746763/142651231-f2fe8b05-06c4-4845-98b0-1794f5a7b573.png"> | <img width="665" alt="image" src="https://user-images.githubusercontent.com/34746763/142652543-8bbfa8b3-8272-41dd-ad79-2e260e6288fb.png">

Update documentation to specify using the `--legacy-peer-deps` flag when running `npm install`.

### Reason for change

Users running the latest version of npm will encounter an error when running `npm install` because of conflicting dependencies. 

Since npm 7, dependency conflicts are no longer automatically solved by installing multiple copies.
Using the `--legacy-peer-deps` flag will restore this behaviour.

The root cause of the dependency conflict cannot be resolved because `angular-material-dynamic-themes` has not been updated to use the version of `@angular/material` that we use.

### Changes summarized

- Add `--legacy-peer-deps` flag to command-line install instructions.

### Suggested future tasks

- Downgrade `@angular/material` to v8
- or, stop using the `angular-material-dynamic-themes` package
- or, require users to use NPM v6.

(In future versions of NPM, the `--legacy-peer-deps` flag may be removed.)

## Checklist

- [x] No new warnings are introduced
- [x] Comments and documentation are up to date
- [x] TODOs resolved or added to issue tracker
- [x] No commented-out code
- [x] This isn't a 'quick-and-dirty' job